### PR TITLE
Don't allow request body and multipart/form-data

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -7,6 +7,7 @@ __N/A__
 
 Bug fixes:
 
+* #7: Don't allow request body when sending multipart/form-data requests
 * #5: Attaching files does not work
 
 v1.0.1

--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@ Attach a file to the request (causing a `multipart/form-data` request, populatin
 | Given I attach "`c:\some\file.jpg`" to the request as `file2`         | `c:\some\file.jpg`      | $\_FILES['`file2`']                          |
 | Given I attach "`features/some.feature`" to the request as `feature`  | `features/some.feature` | $\_FILES['`feature`']                        |
 
+This step can not be used when sending requests with a request body. Doing so results in an `InvalidArgumentException` exception.
+
 #### Given I am authenticating as `:username` with password `:password`
 
 Use this step when the URL you are requesting requires basic auth.

--- a/src/Context/ApiContext.php
+++ b/src/Context/ApiContext.php
@@ -600,9 +600,16 @@ class ApiContext implements ApiClientAwareContext, SnippetAcceptingContext {
      * Set the request body
      *
      * @param string $body The body to set
+     * @throws InvalidArgumentException
      * @return self
      */
     private function setRequestBody($body) {
+        if (isset($this->requestOptions['multipart'])) {
+            throw new InvalidArgumentException(
+                'It\'s not allowed to set a request body when using multipart/form-data.'
+            );
+        }
+
         $this->request = $this->request->withBody(Psr7\stream_for($body));
 
         return $this;

--- a/tests/Context/ApiContextTest.php
+++ b/tests/Context/ApiContextTest.php
@@ -947,4 +947,18 @@ class ApiContextText extends PHPUnit_Framework_TestCase {
         $this->context->whenIRequestPath('/some/path');
         $this->context->thenTheResponseBodyContains(new PyStringNode(['{"bar":"foo"}'], 1));
     }
+
+    /**
+     * @see https://github.com/imbo/behat-api-extension/issues/7
+     * @covers ::setRequestBody
+     */
+    public function testDontAllowRequestBodyWithMultipartFormDataRequests() {
+        $this->mockHandler->append(new Response(200, [], '{"foo":"bar"}'));
+        $this->context->givenIAttachAFileToTheRequest(__FILE__, 'file');
+
+        $this->expectException('InvalidArgumentException');
+        $this->expectExceptionMessage('It\'s not allowed to set a request body when using multipart/form-data');
+
+        $this->context->whenIRequestPathWithBody('/some/path', 'POST', new PyStringNode(['some body'], 1));
+    }
 }


### PR DESCRIPTION
This pull request fixes the issue with using a request body when doing multipart/form-data requests. See #7.