### PR TITLE
Add support for form parameters

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,6 +5,8 @@ v1.0.2
 ------
 __N/A__
 
+* #8: Step(s) for working with form data
+
 Bug fixes:
 
 * #7: Don't allow request body when sending multipart/form-data requests

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ The following configuration options are available for the extension:
 Given I attach :path to the request as :partName
 Given I am authenticating as :username with password :password
 Given the :header request header is :value
+Given the following form parameters are set: <TableNode>
 
 When I request :path
 When I request :path using HTTP :method
@@ -125,6 +126,22 @@ Trying to force specific headers to have certain values combined with other step
 | Given the "`User-Agent`" request header is "`test/1.0`"                                    | `User-Agent` | `test/1.0`        |
 | Given the "`X-Foo`" request header is `Bar`<br>Given the "`X-Foo`" request header is `Baz` | `X-Foo`      | `Bar, Baz`        |
 | Given the `Accept` request header is "`application/json`"                                  | `Accept`     | `application/json`|
+
+#### Given the following form parameters are set: `<TableNode>`
+
+This step can be used to set form parameters (as if the request is a `<form>` being submitted. A table node must be used to specify which fields / values to send:
+
+```gherkin
+Given the following form parameters are set:
+    | name | value |
+    | foo  | bar   |
+    | bar  | foo   |
+    | bar  | bar   |
+```
+
+The first row in the table must contain two values: `name` and `value`. The rows that follows are the fields / values you want to send. This step sets the HTTP method to `POST` and the `Content-Type` request header to `application/x-www-form-urlencoded`, unless the step is combined with `Given I attach :path to the request as :partName`, in which case the `Content-Type` will be `multipart/form-data` and all the specified fields will be sent as parts in the multipart request.
+
+This step can not be used when sending requests with a request body. Doing so results in an `InvalidArgumentException` exception.
 
 ### Send the request
 

--- a/features/bootstrap/index.php
+++ b/features/bootstrap/index.php
@@ -76,6 +76,13 @@ $app->post('/files', function(Request $request) {
 });
 
 /**
+ * Return information about $_POST and $_FILES vars
+ */
+$app->post('/formData', function(Request $request) {
+    return new JsonResponse(['_POST' => $_POST, '_FILES' => $_FILES]);
+});
+
+/**
  * Return the HTTP method
  */
 $app->match('/echoHttpMethod', function(Request $request) {

--- a/features/form-data.feature
+++ b/features/form-data.feature
@@ -1,0 +1,92 @@
+Feature: Test form-data handling
+    In order to test form-data handling
+    As a developer
+    I want to be able to test all related steps
+
+    Background:
+        Given a file named "behat.yml" with:
+            """
+            default:
+                formatters:
+                    progress: ~
+                extensions:
+                    Imbo\BehatApiExtension:
+                        base_uri: http://localhost:8080
+
+                suites:
+                    default:
+                        contexts: ['Imbo\BehatApiExtension\Context\ApiContext']
+            """
+
+    Scenario: Attach form data to the request
+        Given a file named "features/attach-form-data.feature" with:
+            """
+            Feature: Set up the request
+                Scenario: Use the Given step to attach form-data
+                    Given the following form parameters are set:
+                        | name | value |
+                        | foo  | bar   |
+                        | bar  | foo   |
+                        | bar  | bar   |
+                    When I request "/formData"
+                    Then the response body contains:
+                    '''
+                    {
+                        "_POST": {
+                            "foo": "bar",
+                            "bar": ["foo", "bar"]
+                        },
+                        "_FILES": "@length(0)"
+                    }
+                    '''
+
+            """
+        When I run "behat features/attach-form-data.feature"
+        Then it should pass with:
+            """
+            ...
+
+            1 scenario (1 passed)
+            3 steps (3 passed)
+            """
+
+    Scenario: Attach form data and files to the request
+        Given a file named "features/attach-form-data-and-files.feature" with:
+            """
+            Feature: Set up the request
+                Scenario: Use the Given step to attach form-data
+                    Given the following form parameters are set:
+                        | name | value |
+                        | foo  | bar   |
+                        | bar  | foo   |
+                        | bar  | bar   |
+                    And I attach "behat.yml" to the request as file
+                    When I request "/formData"
+                    Then the response body contains:
+                    '''
+                    {
+                        "_POST": {
+                            "foo": "bar",
+                            "bar": ["foo", "bar"]
+                        },
+                        "_FILES": {
+                            "file": {
+                                "name": "behat.yml",
+                                "type": "text/yaml",
+                                "tmp_name": "<re>/.*/</re>",
+                                "error": 0,
+                                "size": "<re>/[0-9]+/</re>"
+                            }
+                        }
+                    }
+                    '''
+
+            """
+        When I run "behat features/attach-form-data-and-files.feature"
+        Then it should pass with:
+            """
+            ....
+
+            1 scenario (1 passed)
+            4 steps (4 passed)
+            """


### PR DESCRIPTION
This pull request adds the following step:

```gherkin
Given the following form parameters are set: <TableNode>
```

Closes #8.