### PR TITLE
Fixes #11: PHP notice when value is array.

### DIFF
--- a/src/ArrayContainsComparator.php
+++ b/src/ArrayContainsComparator.php
@@ -62,11 +62,12 @@ class ArrayContainsComparator {
                 }
 
                 if ($value !== $haystack[$key][$index]) {
+                    $valueStr = (is_array($value)) ? var_export($value, true) : $value;
                     throw new InvalidArgumentException(sprintf(
                         'Item on index %d in array at haystak key "%s" does not match value %s',
                         $index,
                         $keyPath,
-                        $value
+                        $valueStr
                     ));
                 }
 


### PR DESCRIPTION
I got an PHP notice instead the InvalidArgumentException message when $value is array.
This was the case when i used this PyString:
```
Then the response body contains:
      """
        {
          "customer": {
            "images[0]": {
              "filename_client": "myfile.ai"
            }
          }
        }
      """
```