### PR TITLE
Add support for validating a numerical array as the root node

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,6 +1,12 @@
 Changelog for Behat API Extension
 =================================
 
+v1.0.4
+------
+__2016-10-26__
+
+* #15: Add support for checking numerical arrays on root
+
 v1.0.3
 ------
 __2016-10-13__

--- a/README.md
+++ b/README.md
@@ -446,6 +446,36 @@ To assert that one or more of the values exist, use the following:
 
 The index is not taken into consideration when comparing, it simply checks if the values specified are present in the list.
 
+If the response body contains a numerical array as the root node, you will need to use a special syntax for validation. Consider the following response body:
+
+```json
+[
+    "foo",
+    123,
+    {
+        "foo": "bar"
+    },
+    "bar",
+    [1, 2, 3]
+]
+```
+
+To validate this, use the following syntax:
+
+```json
+{
+    "[0]": "foo",
+    "[1]": 123,
+    "[2]": {
+        "foo": "bar"
+    },
+    "[3]": "<re>/bar/</re>",
+    "[4]": "@length(3)"
+}
+```
+
+This simply refers to the indexes in the root numerical array.
+
 ## Extending the extension
 
 If you want to implement your own assertions, or for instance add custom authentication for all requests made against your APIs you can extend the context class provided by the extension to access the client, request, request options and response properties.

--- a/features/thens.feature
+++ b/features/thens.feature
@@ -125,3 +125,48 @@ Feature: Test Then steps
             1 scenario (1 passed)
             3 steps (3 passed)
             """
+
+    Scenario: Use Then steps to verify responses with numerical array as root
+        Given a file named "features/response-with-numerical-array.feature" with:
+            """
+            Feature: Test response body with numerical array as root
+                Scenario: Response returns numerical array
+                    When I request "/echo?json" using HTTP POST with body:
+                    '''
+                    [
+                        1,
+                        "foo",
+                        {
+                            "foo": "bar",
+                            "bar": "foo"
+                        },
+                        [1, 2, 3]
+                    ]
+                    '''
+                    Then the response body is an array of length 4
+                    And the response body contains:
+                    '''
+                    {
+                        "[0]": 1,
+                        "[1]": "foo",
+                        "[2]": {"foo": "bar", "bar": "foo"},
+                        "[3]": [1, 2, 3]
+                    }
+                    '''
+                    And the response body contains:
+                    '''
+                    {
+                        "[1]": "<re>/foo/</re>",
+                        "[3]": "@length(3)"
+                    }
+                    '''
+            """
+        When I run "behat features/response-with-numerical-array.feature"
+        Then it should pass with:
+            """
+            ....
+
+            1 scenario (1 passed)
+            4 steps (4 passed)
+            """
+

--- a/tests/ArrayContainsComparatorTest.php
+++ b/tests/ArrayContainsComparatorTest.php
@@ -389,7 +389,7 @@ class ArrayContainsComparatorText extends PHPUnit_Framework_TestCase {
                 ],
                 'willFail' => true,
                 'exception' => 'InvalidArgumentException',
-                'exceptionMessage' => 'Item on index 0 in array at haystak key "foo" does not match value 2',
+                'exceptionMessage' => 'Item on index 0 in array at haystack key "foo" does not match value 2',
             ],
 
             'match item in array' => [
@@ -632,5 +632,93 @@ class ArrayContainsComparatorText extends PHPUnit_Framework_TestCase {
         // This last assert will only be executed when the comparison succeeds as a failure throws
         // an exception
         $this->assertTrue($this->comparator->compare(['null' => null], ['null' => null]));
+    }
+
+    public function getNumericalArrayValuesAndNeedles() {
+        return [
+            'all checks 2' => [
+                'haystack' => [
+                    1,
+                    'foo',
+                    ['foo' => 'bar', 'bar' => 'foo'],
+                    [1, 2, 3],
+                ],
+                'needle' => [
+                    '[1]' => '<re>/foo/</re>',
+                    '[3]' => '@length(3)',
+                ],
+            ],
+            'all checks' => [
+                'haystack' => [
+                    1,
+                    'foo',
+                    ['foo' => 'bar', 'bar' => 'foo'],
+                    [1, 2, 3],
+                    [1, 2, 3, 4],
+                ],
+                'needle' => [
+                    '[0]' => 1,
+                    '[1]' => 'foo',
+                    '[2]' => [
+                        'foo' => 'bar',
+                        'bar' => '<re>/foo/</re>',
+                    ],
+                    '[3]' => [1, 2, 3],
+                    '[4]' => '@length(4)',
+                ],
+            ],
+            'undefined index' => [
+                'haystack' => [
+                    1,
+                ],
+                'needle' => [
+                    '[1]' => 1,
+                ],
+                'willFail' => true,
+                'exception' => 'OutOfRangeException',
+                'exceptionMessage' => 'Index 1 does not exist in the haystack array',
+            ],
+            'value mismatch' => [
+                'haystack' => [
+                    1,
+                ],
+                'needle' => [
+                    '[0]' => 0,
+                ],
+                'willFail' => true,
+                'exception' => 'InvalidArgumentException',
+                'exceptionMessage' => 'Item on index 0 in array at haystack key "<root>" does not match value 0',
+            ],
+            'nested regular expression mismatch' => [
+                'haystack' => [
+                    [
+                        'foo' => 'bar',
+                        'bar' => 'baz',
+                    ]
+                ],
+                'needle' => [
+                    '[0]' => [
+                        'foo' => '<re>/bar/</re>',
+                        'bar' => '<re>/foo/</re>',
+                    ],
+                ],
+                'willFail' => true,
+                'exception' => 'InvalidArgumentException',
+                'exceptionMessage' => '"regular expression" function failed for the "bar" haystack key',
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider getNumericalArrayValuesAndNeedles
+     * @covers ::compare
+     */
+    public function testCompareWhenRootNodeIsNumericalArray($haystack, $needle, $willFail = false, $exception = null, $exceptionMessage = null) {
+        if ($willFail) {
+            $this->expectException($exception);
+            $this->expectExceptionMessage($exceptionMessage);
+        }
+
+        $this->assertTrue($this->comparator->compare($haystack, $needle));
     }
 }

--- a/tests/Context/ApiContextTest.php
+++ b/tests/Context/ApiContextTest.php
@@ -797,7 +797,7 @@ class ApiContextText extends PHPUnit_Framework_TestCase {
     }
 
     /**
-     * @expectedException Assert\InvalidArgumentException
+     * @expectedException InvalidArgumentException
      * @expectedExceptionMessage The response body does not contain a valid JSON array.
      * @covers ::thenTheResponseBodyIsAnArrayOfLength
      */
@@ -820,7 +820,7 @@ class ApiContextText extends PHPUnit_Framework_TestCase {
     /**
      * @dataProvider getResponseBodyArraysForAtLeast
      * @covers ::thenTheResponseBodyIsAnArrayWithALengthOfAtLeast
-     * @covers ::getResponseBodyArray
+     * @covers ::getResponseBody
      */
     public function testThenTheResponseBodyIsAnArrayWithALengthOfAtLeast(array $body, $lengthToUse, $willFail) {
         $this->mockHandler->append(new Response(200, [], json_encode($body)));
@@ -839,10 +839,10 @@ class ApiContextText extends PHPUnit_Framework_TestCase {
     }
 
     /**
-     * @expectedException Assert\InvalidArgumentException
+     * @expectedException InvalidArgumentException
      * @expectedExceptionMessage The response body does not contain a valid JSON array.
      * @covers ::thenTheResponseBodyIsAnArrayWithALengthOfAtLeast
-     * @covers ::getResponseBodyArray
+     * @covers ::getResponseBody
      */
     public function testThenTheResponseBodyIsAnArrayWithALengthOfAtLeastWithAnInvalidBody() {
         $this->mockHandler->append(new Response(200, [], json_encode(['foo' => 'bar'])));
@@ -863,7 +863,7 @@ class ApiContextText extends PHPUnit_Framework_TestCase {
     /**
      * @dataProvider getResponseBodyArraysForAtMost
      * @covers ::thenTheResponseBodyIsAnArrayWithALengthOfAtMost
-     * @covers ::getResponseBodyArray
+     * @covers ::getResponseBody
      */
     public function testThenTheResponseBodyIsAnArrayWithALengthOfAtMost(array $body, $lengthToUse, $willFail) {
         $this->mockHandler->append(new Response(200, [], json_encode($body)));
@@ -882,10 +882,10 @@ class ApiContextText extends PHPUnit_Framework_TestCase {
     }
 
     /**
-     * @expectedException Assert\InvalidArgumentException
+     * @expectedException InvalidArgumentException
      * @expectedExceptionMessage The response body does not contain a valid JSON array.
      * @covers ::thenTheResponseBodyIsAnArrayWithALengthOfAtMost
-     * @covers ::getResponseBodyArray
+     * @covers ::getResponseBody
      */
     public function testThenTheResponseBodyIsAnArrayWithALengthOfAtMostWithAnInvalidBody() {
         $this->mockHandler->append(new Response(200, [], json_encode(['foo' => 'bar'])));
@@ -904,10 +904,10 @@ class ApiContextText extends PHPUnit_Framework_TestCase {
     }
 
     /**
-     * @expectedException Assert\InvalidArgumentException
-     * @expectedExceptionMessage The response body does not contain a valid JSON object.
+     * @expectedException InvalidArgumentException
+     * @expectedExceptionMessage The response body does not contain a valid JSON array / object.
      * @covers ::thenTheResponseBodyContains
-     * @covers ::getResponseBodyObject
+     * @covers ::getResponseBody
      */
     public function testThenTheResponseBodyContainsWithInvalidJsonInBody() {
         $this->mockHandler->append(new Response(200, [], 'foobar'));
@@ -928,7 +928,7 @@ class ApiContextText extends PHPUnit_Framework_TestCase {
 
     /**
      * @covers ::thenTheResponseBodyContains
-     * @covers ::getResponseBodyObject
+     * @covers ::getResponseBody
      */
     public function testThenTheResponseBodyContains() {
         $this->mockHandler->append(new Response(200, [], '{"foo":"bar","bar":"foo"}'));
@@ -940,7 +940,7 @@ class ApiContextText extends PHPUnit_Framework_TestCase {
      * @expectedException OutOfRangeException
      * @expectedExceptionMessage Key is missing from the haystack: bar
      * @covers ::thenTheResponseBodyContains
-     * @covers ::getResponseBodyObject
+     * @covers ::getResponseBody
      */
     public function testThenTheResponseBodyContainsOnFailure() {
         $this->mockHandler->append(new Response(200, [], '{"foo":"bar"}'));


### PR DESCRIPTION
This pull request allows you to do validation on a response body where the root node is a numerical array. Fixes #15.