### PR TITLE
Addresses issue #20, base_uri fix

### DIFF
--- a/src/Context/ApiContext.php
+++ b/src/Context/ApiContext.php
@@ -154,6 +154,11 @@ class ApiContext implements ApiClientAwareContext, SnippetAcceptingContext {
      * @When I request :path using HTTP :method
      */
     public function whenIRequestPath($path, $method = 'GET') {
+        $existingPath = $this->request->getUri()->getPath();
+        if ($existingPath) {
+            $path = $existingPath . $path;
+        }
+
         $this->setRequestPath($path)
              ->setRequestMethod($method)
              ->sendRequest();


### PR DESCRIPTION
Addresses #20 

 - Adds logic to handle base paths in the base_uri extension
   configuration setting.

   Previously when setting a path to the base_uri it was stripped
   out when later specifying a request path. In
   ApiContext::whenIRequestPath calling Request::setRequestPath
   tells Guzzle to drop the previously set path. This adds logic
   to check for a preset path then appends the new path to that.