### PR TITLE
Allow PATCH method with form parameters

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,7 +5,7 @@ v2.0.1
 ------
 __N/A__
 
-* #48: Allow HTTP PATCH (and other HTTP method) with form parameters (@Tartare2240)
+* #48: Allow HTTP PATCH (and other HTTP methods) with form parameters
 
 v2.0.0
 ------

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,6 +1,12 @@
 Changelog for Behat API Extension
 =================================
 
+v2.0.1
+------
+__N/A__
+
+* #48: Allow HTTP PATCH (and other HTTP method) with form parameters (@Tartare2240)
+
 v2.0.0
 ------
 __2017-04-01__

--- a/docs/guide/setup-request.rst
+++ b/docs/guide/setup-request.rst
@@ -82,9 +82,11 @@ This step can be used to set form parameters (as if the request is a ``<form>`` 
         | bar  | foo   |
         | bar  | bar   |
 
-The first row in the table must contain two values: ``name`` and ``value``. The rows that follows are the fields / values you want to send. This step sets the HTTP method to ``POST`` and the ``Content-Type`` request header to ``application/x-www-form-urlencoded``, unless the step is combined with :ref:`given-i-attach-path-to-the-request-as-partname`, in which case the ``Content-Type`` request header will be set to ``multipart/form-data`` and all the specified fields will be sent as parts in the multipart request.
+The first row in the table must contain two values: ``name`` and ``value``. The rows that follows are the fields / values you want to send. This step sets the HTTP method to ``POST`` by default and the ``Content-Type`` request header to ``application/x-www-form-urlencoded``, unless the step is combined with :ref:`given-i-attach-path-to-the-request-as-partname`, in which case the ``Content-Type`` request header will be set to ``multipart/form-data`` and all the specified fields will be sent as parts in the multipart request.
 
 This step can not be used when sending requests with a request body. Doing so results in an ``InvalidArgumentException`` exception.
+
+To use a different HTTP method, simply specify the wanted method in the :ref:`when-i-request-path-using-http-method` step.
 
 Given the request body is: ``<PyStringNode>``
 ---------------------------------------------

--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -172,18 +172,23 @@ class FeatureContext implements SnippetAcceptingContext {
     public function assertCommandResult($result) {
         $exitCode = $this->getExitCode();
 
+        // Escape % as the callback will pass this value to sprintf() if the assertion fails, and
+        // sprintf might complain about too few arguments as the output might contain stuff like %s
+        // or %d.
+        $output = str_replace('%', '%%', $this->getOutput());
+
         if ($result === 'fail') {
             $callback = 'notEq';
             $errorMessage = sprintf(
                 'Invalid exit code, did not expect 0. Command output: %s',
-                $this->getOutput()
+                $output
             );
         } else {
             $callback = 'eq';
             $errorMessage = sprintf(
                 'Expected exit code 0, got %d. Command output: %s',
                 $exitCode,
-                $this->getOutput()
+                $output
             );
         }
 

--- a/features/bootstrap/index.php
+++ b/features/bootstrap/index.php
@@ -92,10 +92,16 @@ $app->post('/files', function(Request $request) {
 });
 
 /**
- * Return information about $_POST and $_FILES vars
+ * Return information about the request
  */
-$app->post('/formData', function(Request $request) {
-    return new JsonResponse(['_POST' => $_POST, '_FILES' => $_FILES]);
+$app->match('/requestInfo', function(Request $request) {
+    return new JsonResponse([
+        '_GET' => $_GET,
+        '_POST' => $_POST,
+        '_FILES' => $_FILES,
+        '_SERVER' => $_SERVER,
+        'requestBody' => $request->getContent(),
+    ]);
 });
 
 /**

--- a/features/form-data.feature
+++ b/features/form-data.feature
@@ -19,7 +19,7 @@ Feature: Test form-data handling
                         contexts: ['Imbo\BehatApiExtension\Context\ApiContext']
             """
 
-    Scenario: Attach form data to the request
+    Scenario: Attach form data to the request with no HTTP method specified
         Given a file named "features/attach-form-data.feature" with:
             """
             Feature: Set up the request
@@ -29,7 +29,7 @@ Feature: Test form-data handling
                         | foo  | bar   |
                         | bar  | foo   |
                         | bar  | bar   |
-                    When I request "/formData"
+                    When I request "/requestInfo"
                     Then the response body contains JSON:
                     '''
                     {
@@ -37,12 +37,47 @@ Feature: Test form-data handling
                             "foo": "bar",
                             "bar": ["foo", "bar"]
                         },
-                        "_FILES": "@arrayLength(0)"
+                        "_FILES": "@arrayLength(0)",
+                        "_SERVER": {
+                            "REQUEST_METHOD": "POST"
+                        }
                     }
                     '''
 
             """
         When I run "behat features/attach-form-data.feature"
+        Then it should pass with:
+            """
+            ...
+
+            1 scenario (1 passed)
+            3 steps (3 passed)
+            """
+
+    Scenario: Attach form data to the request with custom HTTP method
+        Given a file named "features/attach-form-data-http-patch.feature" with:
+            """
+            Feature: Set up the request
+                Scenario: Use the Given step to attach form-data
+                    Given the following form parameters are set:
+                        | name | value |
+                        | foo  | bar   |
+                        | bar  | foo   |
+                        | bar  | bar   |
+                    When I request "/requestInfo" using HTTP PATCH
+                    Then the response body contains JSON:
+                    '''
+                    {
+                        "_POST": "@arrayLength(0)",
+                        "_SERVER": {
+                            "REQUEST_METHOD": "PATCH"
+                        },
+                        "requestBody": "foo=bar&bar%5B0%5D=foo&bar%5B1%5D=bar"
+                    }
+                    '''
+
+            """
+        When I run "behat features/attach-form-data-http-patch.feature"
         Then it should pass with:
             """
             ...
@@ -62,7 +97,7 @@ Feature: Test form-data handling
                         | bar  | foo   |
                         | bar  | bar   |
                     And I attach "behat.yml" to the request as file
-                    When I request "/formData"
+                    When I request "/requestInfo"
                     Then the response body contains JSON:
                     '''
                     {
@@ -78,6 +113,9 @@ Feature: Test form-data handling
                                 "error": 0,
                                 "size": "@regExp(/[0-9]+/)"
                             }
+                        },
+                        "_SERVER": {
+                            "REQUEST_METHOD": "POST"
                         }
                     }
                     '''

--- a/src/Context/ApiContext.php
+++ b/src/Context/ApiContext.php
@@ -66,6 +66,13 @@ class ApiContext implements ApiClientAwareContext, ArrayContainsComparatorAwareC
     protected $arrayContainsComparator;
 
     /**
+     * Does HTTP method has been manually set
+     *
+     * @var bool
+     */
+    protected $httpMethodSpecified = false;
+
+    /**
      * {@inheritdoc}
      */
     public function setClient(ClientInterface $client) {
@@ -256,11 +263,14 @@ class ApiContext implements ApiClientAwareContext, ArrayContainsComparatorAwareC
      * @When I request :path
      * @When I request :path using HTTP :method
      */
-    public function requestPath($path, $method = 'GET') {
-        return $this
-            ->setRequestPath($path)
-            ->setRequestMethod($method)
-            ->sendRequest();
+    public function requestPath($path, $method = null) {
+        $this->setRequestPath($path);
+
+        if (null !== $method) {
+            $this->setRequestMethod($method);
+        }
+
+        return $this->sendRequest();
     }
 
     /**
@@ -914,7 +924,7 @@ class ApiContext implements ApiClientAwareContext, ArrayContainsComparatorAwareC
      * @return self
      */
     protected function sendRequest() {
-        if (!empty($this->requestOptions['form_params'])) {
+        if (!empty($this->requestOptions['form_params']) && !$this->httpMethodSpecified) {
             $this->setRequestMethod('POST');
         }
 
@@ -1076,6 +1086,7 @@ class ApiContext implements ApiClientAwareContext, ArrayContainsComparatorAwareC
      */
     protected function setRequestMethod($method) {
         $this->request = $this->request->withMethod($method);
+        $this->httpMethodSpecified = true;
 
         return $this;
     }

--- a/tests/Context/ApiContextTest.php
+++ b/tests/Context/ApiContextTest.php
@@ -118,6 +118,7 @@ class ApiContextText extends PHPUnit_Framework_TestCase {
             ['method' => 'HEAD'],
             ['method' => 'OPTIONS'],
             ['method' => 'DELETE'],
+            ['method' => 'PATCH'],
         ];
     }
 
@@ -557,11 +558,28 @@ class ApiContextText extends PHPUnit_Framework_TestCase {
     }
 
     /**
+     * Data provider
+     *
+     * @return array[]
+     */
+    public function getHttpMethodsForFormParametersTest() {
+        return [
+            ['httpMethod' => 'PUT'],
+            ['httpMethod' => 'POST'],
+            ['httpMethod' => 'PATCH'],
+            ['httpMethod' => 'DELETE'],
+        ];
+    }
+
+    /**
+     * @dataProvider getHttpMethodsForFormParametersTest
      * @covers ::setRequestFormParams
      * @covers ::sendRequest
      * @group setup
+     *
+     * @param string $httpMethod The HTTP method
      */
-    public function testCanSetFormParametersInTheRequestWithPatchMethod() {
+    public function testCanSetFormParametersInTheRequestWithCustomMethod($httpMethod) {
         $this->mockHandler->append(new Response(200));
         $this->assertSame($this->context, $this->context->setRequestFormParams(new TableNode([
             ['name', 'value'],
@@ -569,18 +587,17 @@ class ApiContextText extends PHPUnit_Framework_TestCase {
             ['bar', 'foo'],
             ['bar', 'bar'],
         ])));
-        $this->context->requestPath('/some/path', 'PATCH');
+        $this->context->requestPath('/some/path', $httpMethod);
 
         $this->assertSame(1, count($this->historyContainer));
 
         $request = $this->historyContainer[0]['request'];
 
-        $this->assertSame('PATCH', $request->getMethod());
+        $this->assertSame($httpMethod, $request->getMethod());
         $this->assertSame('application/x-www-form-urlencoded', $request->getHeaderLine('Content-Type'));
         $this->assertSame(37, (int) $request->getHeaderLine('Content-Length'));
         $this->assertSame('foo=bar&bar%5B0%5D=foo&bar%5B1%5D=bar', (string) $request->getBody());
     }
-
 
     /**
      * @covers ::sendRequest

--- a/tests/Context/ApiContextTest.php
+++ b/tests/Context/ApiContextTest.php
@@ -557,6 +557,32 @@ class ApiContextText extends PHPUnit_Framework_TestCase {
     }
 
     /**
+     * @covers ::setRequestFormParams
+     * @covers ::sendRequest
+     * @group setup
+     */
+    public function testCanSetFormParametersInTheRequestWithPatchMethod() {
+        $this->mockHandler->append(new Response(200));
+        $this->assertSame($this->context, $this->context->setRequestFormParams(new TableNode([
+            ['name', 'value'],
+            ['foo', 'bar'],
+            ['bar', 'foo'],
+            ['bar', 'bar'],
+        ])));
+        $this->context->requestPath('/some/path', 'PATCH');
+
+        $this->assertSame(1, count($this->historyContainer));
+
+        $request = $this->historyContainer[0]['request'];
+
+        $this->assertSame('PATCH', $request->getMethod());
+        $this->assertSame('application/x-www-form-urlencoded', $request->getHeaderLine('Content-Type'));
+        $this->assertSame(37, (int) $request->getHeaderLine('Content-Length'));
+        $this->assertSame('foo=bar&bar%5B0%5D=foo&bar%5B1%5D=bar', (string) $request->getBody());
+    }
+
+
+    /**
      * @covers ::sendRequest
      * @group setup
      */


### PR DESCRIPTION
I would like to be able to use a form with `PATCH` method. This PR just doesn't change the method if it is `POST` and `PATCH`.

There shouldn't be regressions except the case if someone called a `PATCH` method and expected a `POST`.