### PR TITLE
Use HTTP GET when no method is specified

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,6 +46,7 @@
     "clean": "rm -rf build",
     "lint": "for file in `git ls-files '*php'`; do php -l $file; done",
     "test-phpunit": "vendor/bin/phpunit",
+    "test-phpunit-coverage": "vendor/bin/phpunit --coverage-html build/coverage",
     "test-behat": "vendor/bin/behat --strict",
     "test": [
       "@test-phpunit",

--- a/composer.json
+++ b/composer.json
@@ -52,7 +52,7 @@
       "@test-phpunit",
       "@test-behat"
     ],
-    "start-server": "php -S localhost:8080 -t ./features/bootstrap > server.log 2>&1 &",
+    "dev": "php -S localhost:8080 -t ./features/bootstrap > server.log 2>&1",
     "docs": [
       "cd docs; make spelling",
       "cd docs; make html"

--- a/src/Context/ApiContext.php
+++ b/src/Context/ApiContext.php
@@ -72,7 +72,7 @@ class ApiContext implements ApiClientAwareContext, ArrayContainsComparatorAwareC
      *
      * @var bool
      */
-    protected $httpMethodSpecified = false;
+    protected $forceHttpMethod = false;
 
     /**
      * {@inheritdoc}
@@ -950,7 +950,7 @@ class ApiContext implements ApiClientAwareContext, ArrayContainsComparatorAwareC
      * @return self
      */
     protected function sendRequest() {
-        if (!empty($this->requestOptions['form_params']) && !$this->httpMethodSpecified) {
+        if (!empty($this->requestOptions['form_params']) && !$this->forceHttpMethod) {
             $this->setRequestMethod('POST');
         }
 
@@ -1115,7 +1115,7 @@ class ApiContext implements ApiClientAwareContext, ArrayContainsComparatorAwareC
      */
     protected function setRequestMethod($method, $force = true) {
         $this->request = $this->request->withMethod($method);
-        $this->httpMethodSpecified = $force;
+        $this->forceHttpMethod = $force;
 
         return $this;
     }

--- a/src/Context/ApiContext.php
+++ b/src/Context/ApiContext.php
@@ -294,7 +294,9 @@ class ApiContext implements ApiClientAwareContext, ArrayContainsComparatorAwareC
     public function requestPath($path, $method = null) {
         $this->setRequestPath($path);
 
-        if (null !== $method) {
+        if (null === $method) {
+            $this->setRequestMethod('GET', false);
+        } else {
             $this->setRequestMethod($method);
         }
 
@@ -1106,11 +1108,14 @@ class ApiContext implements ApiClientAwareContext, ArrayContainsComparatorAwareC
      * Update the HTTP method of the request
      *
      * @param string $method The HTTP method
+     * @param boolean $force Force the HTTP method. If set to false the method set CAN be
+     *                       overridden (this occurs for instance when adding form parameters to the
+     *                       request, and not specifying HTTP POST for the request)
      * @return self
      */
-    protected function setRequestMethod($method) {
+    protected function setRequestMethod($method, $force = true) {
         $this->request = $this->request->withMethod($method);
-        $this->httpMethodSpecified = true;
+        $this->httpMethodSpecified = $force;
 
         return $this;
     }

--- a/tests/Context/ApiContextTest.php
+++ b/tests/Context/ApiContextTest.php
@@ -1905,4 +1905,28 @@ BAR;
         $this->context->requestPath('/some/path');
         $this->context->assertResponseBodyContainsJson(new PyStringNode(["{'foo':'bar'}"], 1));
     }
+
+    /**
+     * @covers ::requestPath
+     * @see https://github.com/imbo/behat-api-extension/issues/51
+     */
+    public function testUsesHttpGetByDefaultWhenRequesting() {
+        $this->mockHandler->append(new Response(200), new Response(200));
+
+        $this->context->requestPath('/some/path', 'POST');
+        $this->context->requestPath('/some/path');
+
+        $this->assertSame(2, count($this->historyContainer));
+
+        $this->assertSame(
+            'POST',
+            $this->historyContainer[0]['request']->getMethod(),
+            'Expected first request to use HTTP POST'
+        );
+        $this->assertSame(
+            'GET',
+            $this->historyContainer[1]['request']->getMethod(),
+            'Expected second request to use HTTP GET (default)'
+        );
+    }
 }

--- a/tests/Context/ApiContextTest.php
+++ b/tests/Context/ApiContextTest.php
@@ -1908,6 +1908,7 @@ BAR;
 
     /**
      * @covers ::requestPath
+     * @covers ::setRequestMethod
      * @see https://github.com/imbo/behat-api-extension/issues/51
      */
     public function testUsesHttpGetByDefaultWhenRequesting() {


### PR DESCRIPTION
The requestPath method will not specify HTTP GET internally if no method is given to the step:

     When I request :path

vs

    When I request :path using HTTP :method

This PR will make the extension use `GET` if no other method is explicitly specified, and when automatically doing so it will allow the HTTP method to be overridden internally, if for instance form parameters have been added. When a method is specified using the `When I request :path using HTTP :method` step it can not be overridden internally.

Resolves #51.