### PR TITLE
Check individual payload properties instead of whole array

### DIFF
--- a/docs/guide/setup-request.rst
+++ b/docs/guide/setup-request.rst
@@ -133,8 +133,9 @@ This step can be used to prepare the `JWT <https://jwt.io/>`_ custom matcher fun
     Given the response body contains a JWT identified by "my JWT", signed with "some secret":
         """
         {
-            "some": "data"
+            "some": "data",
+            "value": "@regExp(/(some|expression)/i)"
         }
         """
 
-The above step would register a JWT which can be matched with ``@jwt(my JWT)`` using the :ref:`@jwt() <jwt-custom-matcher>` custom matcher function.
+The above step would register a JWT which can be matched with ``@jwt(my JWT)`` using the :ref:`@jwt() <jwt-custom-matcher>` custom matcher function. The way the payload is matched is similar to matching a JSON response body, as explained in the :ref:`then-the-response-body-contains-json` section, which means :ref:`custom matcher functions <custom-matcher-functions-and-targeting>` can be used, as seen in the example above.

--- a/features/jwt-matcher.feature
+++ b/features/jwt-matcher.feature
@@ -1,0 +1,113 @@
+Feature: Test built in jwt matcher functions
+    In order to test the extension
+    As a developer
+    I want to be able to test all available steps
+
+    Background:
+        Given a file named "behat.yml" with:
+            """
+            default:
+                formatters:
+                    progress: ~
+                extensions:
+                    Imbo\BehatApiExtension:
+                        apiClient:
+                            base_uri: http://localhost:8080
+
+                suites:
+                    default:
+                        contexts: ['Imbo\BehatApiExtension\Context\ApiContext']
+            """
+
+    Scenario: Use array contains comparator with JWT
+        Given a file named "features/jwt.feature" with:
+            """
+            Feature:
+                Scenario:
+                    Given the response body contains a JWT identified by "jwt1", signed with "secret":
+                        '''
+                        {
+                            "sub": "1234567890",
+                            "name": "John Doe",
+                            "admin": true
+                        }
+                        '''
+                    And the response body contains a JWT identified by "jwt2", signed with "secret":
+                        '''
+                        {
+                            "sub": "@variableType(string)",
+                            "name": "@variableType(string)",
+                            "admin": "@variableType(boolean)"
+                        }
+                        '''
+                    And the response body contains a JWT identified by "jwt3", signed with "secret":
+                        '''
+                        {
+                            "sub": "@regExp(/^[0-9]+$/)"
+                        }
+                        '''
+                    And the request body is:
+                        '''
+                        {
+                            "jwt": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWV9.TJVA95OrM7E2cBab30RMHrHDcEfxjoYZgeFONFh7HgQ"
+                        }
+                        '''
+                    When I request "/echo?json" using HTTP POST
+                    Then the response body contains JSON:
+                        '''
+                        {
+                            "jwt": "@jwt(jwt1)"
+                        }
+                        '''
+                    And the response body contains JSON:
+                        '''
+                        {
+                            "jwt": "@jwt(jwt2)"
+                        }
+                        '''
+                    And the response body contains JSON:
+                        '''
+                        {
+                            "jwt": "@jwt(jwt3)"
+                        }
+                        '''
+            """
+        When I run "behat features/jwt.feature"
+        Then it should pass with:
+            """
+            ........
+
+            1 scenario (1 passed)
+            8 steps (8 passed)
+            """
+
+    Scenario: Use array contains comparator with JWT with failures
+        Given a file named "features/jwt-failures.feature" with:
+            """
+            Feature:
+                Scenario:
+                    Given the response body contains a JWT identified by "jwt1", signed with "secret":
+                        '''
+                        {
+                            "sub1": "1234567890"
+                        }
+                        '''
+                    And the request body is:
+                        '''
+                        {
+                            "jwt": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWV9.TJVA95OrM7E2cBab30RMHrHDcEfxjoYZgeFONFh7HgQ"
+                        }
+                        '''
+                    When I request "/echo?json" using HTTP POST
+                    Then the response body contains JSON:
+                        '''
+                        {
+                            "jwt": "@jwt(jwt1)"
+                        }
+                        '''
+            """
+        When I run "behat features/jwt-failures.feature"
+        Then it should fail with:
+            """
+            Function "jwt" failed with error message: "Haystack object is missing the "sub1" key.
+            """

--- a/src/ArrayContainsComparator/Matcher/JWT.php
+++ b/src/ArrayContainsComparator/Matcher/JWT.php
@@ -54,10 +54,12 @@ class JWT {
 
         $result = (array) Firebase\JWT\JWT::decode($jwt, $token['secret'], ['HS256', 'HS384', 'HS512']);
 
-        if ($result !== $token['payload']) {
-            throw new InvalidArgumentException(sprintf(
-                'JWT mismatch.'
-            ));
+        foreach ($token['payload'] as $key => $value) {
+            if (!array_key_exists($key, $result) || $result[$key] !== $value) {
+                throw new InvalidArgumentException(sprintf(
+                    'JWT mismatch.'
+                ));
+            }
         }
     }
 }

--- a/src/ArrayContainsComparator/Matcher/JWT.php
+++ b/src/ArrayContainsComparator/Matcher/JWT.php
@@ -13,6 +13,8 @@ use Imbo\BehatApiExtension\ArrayContainsComparator as Comparator;
  */
 class JWT {
     /**
+     * Comparator for the array
+     *
      * @var Comparator
      */
     private $comparator;
@@ -25,10 +27,22 @@ class JWT {
     private $jwtTokens = [];
 
     /**
+     * Allowed algorithms for the JWT decoder
+     *
+     * @var string[]
+     */
+    protected $allowedAlgorithms = [
+        'HS256',
+        'HS384',
+        'HS512',
+    ];
+
+    /**
+     * Class constructor
+     *
      * @param Comparator $comparator
      */
-    public function __construct(Comparator $comparator)
-    {
+    public function __construct(Comparator $comparator) {
         $this->comparator = $comparator;
     }
 
@@ -59,19 +73,14 @@ class JWT {
      */
     public function __invoke($jwt, $name) {
         if (!isset($this->jwtTokens[$name])) {
-            throw new InvalidArgumentException(sprintf(
-                'No JWT registered for "%s".',
-                $name
-            ));
+            throw new InvalidArgumentException(sprintf('No JWT registered for "%s".', $name));
         }
 
         $token  = $this->jwtTokens[$name];
-        $result = (array) Firebase\JWT\JWT::decode($jwt, $token['secret'], ['HS256', 'HS384', 'HS512']);
+        $result = (array) Firebase\JWT\JWT::decode($jwt, $token['secret'], $this->allowedAlgorithms);
 
         if (!$this->comparator->compare($token['payload'], $result)) {
-            throw new InvalidArgumentException(sprintf(
-                'JWT mismatch.'
-            ));
+            throw new InvalidArgumentException('JWT mismatch.');
         }
     }
 }

--- a/src/Context/Initializer/ArrayContainsComparatorAwareInitializer.php
+++ b/src/Context/Initializer/ArrayContainsComparatorAwareInitializer.php
@@ -32,7 +32,7 @@ class ArrayContainsComparatorAwareInitializer implements ContextInitializer {
             ->addFunction('regExp', new Matcher\RegExp())
             ->addFunction('gt', new Matcher\GreaterThan())
             ->addFunction('lt', new Matcher\LessThan())
-            ->addFunction('jwt', new Matcher\JWT());
+            ->addFunction('jwt', new Matcher\JWT($comparator));
 
         $this->comparator = $comparator;
     }

--- a/tests/ArrayContainsComparator/Matcher/JWTTest.php
+++ b/tests/ArrayContainsComparator/Matcher/JWTTest.php
@@ -2,6 +2,7 @@
 namespace Imbo\BehatApiExtension\ArrayContainsComparator\Matcher;
 
 use Imbo\BehatApiExtension\ArrayContainsComparator;
+use Imbo\BehatApiExtension\ArrayContainsComparator\Exception\ArrayContainsComparatorException;
 use PHPUnit_Framework_TestCase;
 
 /**
@@ -60,7 +61,7 @@ class JWTTest extends PHPUnit_Framework_TestCase {
     }
 
     /**
-     * @expectedException \Imbo\BehatApiExtension\Exception\ArrayContainsComparatorException
+     * @expectedException Imbo\BehatApiExtension\Exception\ArrayContainsComparatorException
      * @expectedExceptionMessage Haystack object is missing the "some" key.
      * @covers ::addToken
      * @covers ::__invoke
@@ -87,6 +88,32 @@ class JWTTest extends PHPUnit_Framework_TestCase {
         $matcher(
             $jwt,
             $name
+        );
+    }
+
+    /**
+     * @expectedException InvalidArgumentException
+     * @expectedExceptionMessage JWT mismatch.
+     * @covers ::__construct
+     * @covers ::__invoke
+     */
+    public function testThrowsExceptionWhenComparatorDoesNotReturnSuccess() {
+        $comparator = $this->createConfiguredMock(ArrayContainsComparator::class, [
+            'compare' => false,
+        ]);
+        $matcher = (new JWT($comparator))->addToken(
+            'token',
+            [
+                'sub' => '1234567890',
+                'name' => 'John Doe',
+                'admin' => true,
+            ],
+            'secret'
+        );
+
+        $matcher(
+            'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWV9.TJVA95OrM7E2cBab30RMHrHDcEfxjoYZgeFONFh7HgQ',
+            'token'
         );
     }
 }

--- a/tests/ArrayContainsComparator/Matcher/JWTTest.php
+++ b/tests/ArrayContainsComparator/Matcher/JWTTest.php
@@ -1,6 +1,7 @@
 <?php
 namespace Imbo\BehatApiExtension\ArrayContainsComparator\Matcher;
 
+use Imbo\BehatApiExtension\ArrayContainsComparator;
 use PHPUnit_Framework_TestCase;
 
 /**
@@ -17,7 +18,7 @@ class JWTTest extends PHPUnit_Framework_TestCase {
      * Set up matcher instance
      */
     public function setup() {
-        $this->matcher = new JWT();
+        $this->matcher = new JWT(new ArrayContainsComparator());
     }
 
     /**
@@ -59,8 +60,8 @@ class JWTTest extends PHPUnit_Framework_TestCase {
     }
 
     /**
-     * @expectedException InvalidArgumentException
-     * @expectedExceptionMessage JWT mismatch.
+     * @expectedException \Imbo\BehatApiExtension\Exception\ArrayContainsComparatorException
+     * @expectedExceptionMessage Haystack object is missing the "some" key.
      * @covers ::addToken
      * @covers ::__invoke
      */

--- a/tests/ArrayContainsComparatorTest.php
+++ b/tests/ArrayContainsComparatorTest.php
@@ -409,7 +409,7 @@ EXCEPTION
             ],
             '@jwt' => [
                 'function' => 'jwt',
-                'callback' => (new Matcher\JWT())->addToken('my jwt', ['some' => 'data'], 'secret', 'HS256'),
+                'callback' => (new Matcher\JWT(new ArrayContainsComparator()))->addToken('my jwt', ['some' => 'data'], 'secret', 'HS256'),
                 'needle' => [
                     'key' => '@jwt(my jwt)',
                 ],


### PR DESCRIPTION
Its almost impossible to test generated payload values like the expired the way the JWT matcher works.
I suggest checking the properties that are given in the jwt token you want to check.