### PR TITLE
change base_uri validation

### DIFF
--- a/features/context.feature
+++ b/features/context.feature
@@ -75,5 +75,5 @@ Feature: Client aware context
         When I run "behat -f progress features/client.feature"
         Then it should fail with:
             """
-            Invalid configuration for path "testwork.api_extension.apiClient.base_uri": Can't connect to base_uri: "http://localhost:9999".
+            Can't connect to base_uri: "http://localhost:9999".
             """

--- a/src/ArrayContainsComparator/Matcher/JWT.php
+++ b/src/ArrayContainsComparator/Matcher/JWT.php
@@ -1,7 +1,6 @@
 <?php
 namespace Imbo\BehatApiExtension\ArrayContainsComparator\Matcher;
 
-use Assert\Assertion;
 use Firebase;
 use InvalidArgumentException;
 use Imbo\BehatApiExtension\ArrayContainsComparator as Comparator;

--- a/src/Context/Initializer/ApiClientAwareInitializer.php
+++ b/src/Context/Initializer/ApiClientAwareInitializer.php
@@ -5,6 +5,7 @@ use Imbo\BehatApiExtension\Context\ApiClientAwareContext;
 use Behat\Behat\Context\Context;
 use Behat\Behat\Context\Initializer\ContextInitializer;
 use GuzzleHttp\Client;
+use RuntimeException;
 
 /**
  * API client aware initializer
@@ -37,7 +38,43 @@ class ApiClientAwareInitializer implements ContextInitializer {
      */
     public function initializeContext(Context $context) {
         if ($context instanceof ApiClientAwareContext) {
+            // Fetch base URI from the Guzzle client configuration, if it exists
+            $baseUri = !empty($this->guzzleConfig['base_uri']) ? $this->guzzleConfig['base_uri'] : null;
+
+            if ($baseUri && !$this->validateConnection($baseUri)) {
+                throw new RuntimeException(sprintf('Can\'t connect to base_uri: "%s".', $baseUri));
+            }
+
             $context->setClient(new Client($this->guzzleConfig));
         }
+    }
+
+    /**
+     * Validate a connection to the base URI
+     *
+     * @param string $baseUri
+     * @return boolean
+     */
+    private function validateConnection($baseUri) {
+        $parts = parse_url($baseUri);
+        $host = $parts['host'];
+        $port = isset($parts['port']) ? $parts['port'] : ($parts['scheme'] === 'https' ? 443 : 80);
+
+        set_error_handler(function () {
+            return true;
+        });
+
+        $resource = fsockopen($host, $port);
+        restore_error_handler();
+
+        if ($resource === false) {
+            // Can't connect
+            return false;
+        }
+
+        // Connection successful, close connection
+        fclose($resource);
+
+        return true;
     }
 }

--- a/src/ServiceContainer/BehatApiExtension.php
+++ b/src/ServiceContainer/BehatApiExtension.php
@@ -8,8 +8,6 @@ use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Reference;
-use GuzzleHttp\ClientInterface;
-use InvalidArgumentException;
 
 /**
  * Behat API extension
@@ -78,35 +76,8 @@ class BehatApiExtension implements ExtensionInterface {
                             ->isRequired()
                             ->cannotBeEmpty()
                             ->defaultValue('http://localhost:8080')
-                            ->validate()
-                            ->ifTrue(function($uri) {
-                                $parts = parse_url($uri);
-                                $host = $parts['host'];
-                                $port = isset($parts['port']) ? $parts['port'] : ($parts['scheme'] === 'https' ? 443 : 80);
-
-                                set_error_handler(function() { return true; });
-                                $resource = fsockopen($host, $port);
-                                restore_error_handler();
-
-                                if ($resource === false) {
-                                    // Can't connect, return true to mark as failure
-                                    return true;
-                                }
-
-                                // Connection successful, close connection and return false to mark
-                                // as success
-                                fclose($resource);
-
-                                return false;
-                            })
-                                ->then(function($uri) {
-                                    throw new InvalidArgumentException(sprintf('Can\'t connect to base_uri: "%s".', $uri));
-                                })
-                            ->end()
                         ->end()
-                    ->end()
-                ->end()
-            ->end();
+                    ->end();
     }
 
     /**

--- a/src/ServiceContainer/BehatApiExtension.php
+++ b/src/ServiceContainer/BehatApiExtension.php
@@ -1,6 +1,9 @@
 <?php
 namespace Imbo\BehatApiExtension\ServiceContainer;
 
+use Imbo\BehatApiExtension\Context\Initializer\ApiClientAwareInitializer;
+use Imbo\BehatApiExtension\ArrayContainsComparator;
+use Imbo\BehatApiExtension\Context\Initializer\ArrayContainsComparatorAwareInitializer;
 use Behat\Behat\Context\ServiceContainer\ContextExtension;
 use Behat\Testwork\ServiceContainer\Extension as ExtensionInterface;
 use Behat\Testwork\ServiceContainer\ExtensionManager;
@@ -87,7 +90,7 @@ class BehatApiExtension implements ExtensionInterface {
     public function load(ContainerBuilder $container, array $config) {
         // Client initializer definition
         $clientInitializerDefinition = new Definition(
-            'Imbo\BehatApiExtension\Context\Initializer\ApiClientAwareInitializer',
+            ApiClientAwareInitializer::class,
             [
                 $config['apiClient']
             ]
@@ -95,13 +98,11 @@ class BehatApiExtension implements ExtensionInterface {
         $clientInitializerDefinition->addTag(ContextExtension::INITIALIZER_TAG);
 
         // Definition for the array contains comparator
-        $comparatorDefinition = new Definition(
-            'Imbo\BehatApiExtension\ArrayContainsComparator'
-        );
+        $comparatorDefinition = new Definition(ArrayContainsComparator::class);
 
         // Comparator initializer definition
         $comparatorInitializerDefinition = new Definition(
-            'Imbo\BehatApiExtension\Context\Initializer\ArrayContainsComparatorAwareInitializer',
+            ArrayContainsComparatorAwareInitializer::class,
             [
                 new Reference(self::COMPARATOR_SERVICE_ID)
             ]

--- a/tests/Context/ApiContextTest.php
+++ b/tests/Context/ApiContextTest.php
@@ -1,6 +1,7 @@
 <?php
 namespace Imbo\BehatApiExtension\Context;
 
+use Imbo\BehatApiExtension\ArrayContainsComparator;
 use Imbo\BehatApiExtension\ArrayContainsComparator\Matcher\JWT;
 use PHPUnit_Framework_TestCase;
 use GuzzleHttp\Client;
@@ -99,7 +100,7 @@ class ApiContextText extends PHPUnit_Framework_TestCase {
             'handler' => $this->handlerStack,
             'base_uri' => $this->baseUri,
         ]);
-        $this->comparator = $this->createMock('Imbo\BehatApiExtension\ArrayContainsComparator');
+        $this->comparator = $this->createMock(ArrayContainsComparator::class);
 
         $this->context = new ApiContext();
         $this->context->setClient($this->client);

--- a/tests/Context/Initializer/ApiClientAwareInitializerTest.php
+++ b/tests/Context/Initializer/ApiClientAwareInitializerTest.php
@@ -12,6 +12,7 @@ use PHPUnit_Framework_TestCase;
 class ApiClientAwareInitializerTest extends PHPUnit_Framework_TestCase {
     /**
      * @covers ::initializeContext
+     * @covers ::validateConnection
      * @expectedException RuntimeException
      * @expectedExceptionMessage Can't connect to base_uri: "http://localhost:123".
      */
@@ -22,16 +23,44 @@ class ApiClientAwareInitializerTest extends PHPUnit_Framework_TestCase {
 
     /**
      * @covers ::initializeContext
+     * @covers ::validateConnection
      * @covers ::__construct
      */
     public function testInjectsClientWhenInitializingContext() {
+        // Set up a socket for the test case, try all ports between 8000 and 8079. If no ports are
+        // available the test case will be marked as skipped. This is to get past the base URI
+        // validation
+        set_error_handler(function() { return true; });
+        $sock = socket_create(AF_INET, SOCK_STREAM, SOL_TCP);
+
+        for ($port = 8000; $port < 8079; $port++) {
+            if ($result = socket_bind($sock, 'localhost', $port)) {
+                break;
+            }
+        }
+
+        restore_error_handler();
+
+        if (!$result) {
+            // No port was available
+            $this->markTestSkipped('Could not create a socket, skipping test for now.');
+        }
+
+        // Listen for connections
+        socket_listen($sock);
+
         $context = $this->createMock(ApiClientAwareContext::class);
         $context
             ->expects($this->once())
             ->method('setClient')
             ->with($this->isInstanceOf(Client::class));
 
-        $initializer = new ApiClientAwareInitializer([]); // Don't pass base_uri to skip validation
+        $initializer = new ApiClientAwareInitializer([
+            'base_uri' => sprintf('http://localhost:%d', $port),
+        ]);
         $initializer->initializeContext($context);
+
+        // Close socket used in test case
+        socket_close($sock);
     }
 }

--- a/tests/Context/Initializer/ApiClientAwareInitializerTest.php
+++ b/tests/Context/Initializer/ApiClientAwareInitializerTest.php
@@ -13,6 +13,20 @@ use RuntimeException;
 class ApiClientAwareInitializerTest extends PHPUnit_Framework_TestCase {
     /**
      * @covers ::initializeContext
+     * @expectedException RuntimeException
+     * @expectedExceptionMessage Can't connect to base_uri: "http://localhost:123".
+     */
+    public function testThrowsExceptionWhenBaseUriIsNotConnectable() {
+
+        $baseUri = 'http://localhost:123';
+        $context = $this->createMock('Imbo\BehatApiExtension\Context\ApiClientAwareContext');
+
+        $initializer = new ApiClientAwareInitializer(['base_uri' => $baseUri]);
+        $initializer->initializeContext($context);
+    }
+
+    /**
+     * @covers ::initializeContext
      * @covers ::__construct
      */
     public function testInjectsClientWhenInitializingContext() {

--- a/tests/Context/Initializer/ApiClientAwareInitializerTest.php
+++ b/tests/Context/Initializer/ApiClientAwareInitializerTest.php
@@ -1,10 +1,9 @@
 <?php
 namespace Imbo\BehatApiExtension\Context\Initializer;
 
-use Behat\Behat\Context\Context;
+use Imbo\BehatApiExtension\Context\ApiClientAwareContext;
 use GuzzleHttp\Client;
 use PHPUnit_Framework_TestCase;
-use RuntimeException;
 
 /**
  * @coversDefaultClass Imbo\BehatApiExtension\Context\Initializer\ApiClientAwareInitializer
@@ -17,12 +16,8 @@ class ApiClientAwareInitializerTest extends PHPUnit_Framework_TestCase {
      * @expectedExceptionMessage Can't connect to base_uri: "http://localhost:123".
      */
     public function testThrowsExceptionWhenBaseUriIsNotConnectable() {
-
-        $baseUri = 'http://localhost:123';
-        $context = $this->createMock('Imbo\BehatApiExtension\Context\ApiClientAwareContext');
-
-        $initializer = new ApiClientAwareInitializer(['base_uri' => $baseUri]);
-        $initializer->initializeContext($context);
+        $initializer = new ApiClientAwareInitializer(['base_uri' => 'http://localhost:123']);
+        $initializer->initializeContext($this->createMock(ApiClientAwareContext::class));
     }
 
     /**
@@ -30,16 +25,13 @@ class ApiClientAwareInitializerTest extends PHPUnit_Framework_TestCase {
      * @covers ::__construct
      */
     public function testInjectsClientWhenInitializingContext() {
-        $baseUri = 'http://localhost:8080';
-        $context = $this->createMock('Imbo\BehatApiExtension\Context\ApiClientAwareContext');
+        $context = $this->createMock(ApiClientAwareContext::class);
         $context
             ->expects($this->once())
             ->method('setClient')
-            ->with($this->callback(function($client) use ($baseUri) {
-                return (string) $client->getConfig('base_uri') === $baseUri;
-            }));
+            ->with($this->isInstanceOf(Client::class));
 
-        $initializer = new ApiClientAwareInitializer(['base_uri' => $baseUri]);
+        $initializer = new ApiClientAwareInitializer([]); // Don't pass base_uri to skip validation
         $initializer->initializeContext($context);
     }
 }

--- a/tests/Context/Initializer/ArrayContainsComparatorAwareInitializerTest.php
+++ b/tests/Context/Initializer/ArrayContainsComparatorAwareInitializerTest.php
@@ -1,6 +1,7 @@
 <?php
 namespace Imbo\BehatApiExtension\Context\Initializer;
 
+use Imbo\BehatApiExtension\Context\ArrayContainsComparatorAwareContext;
 use Imbo\BehatApiExtension\ArrayContainsComparator;
 use Imbo\BehatApiExtension\ArrayContainsComparator\Matcher;
 use PHPUnit_Framework_TestCase;
@@ -14,19 +15,19 @@ class ArrayContainsComparatorAwareInitializerTest extends PHPUnit_Framework_Test
      * @covers ::__construct
      */
     public function testInitializerInjectsDefaultMatcherFunctions() {
-        $comparator = $this->createMock('Imbo\BehatApiExtension\ArrayContainsComparator');
+        $comparator = $this->createMock(ArrayContainsComparator::class);
         $comparator
             ->expects($this->exactly(8))
             ->method('addFunction')
             ->withConsecutive(
-                ['arrayLength', $this->isInstanceOf('Imbo\BehatApiExtension\ArrayContainsComparator\Matcher\ArrayLength')],
-                ['arrayMinLength', $this->isInstanceOf('Imbo\BehatApiExtension\ArrayContainsComparator\Matcher\ArrayMinLength')],
-                ['arrayMaxLength', $this->isInstanceOf('Imbo\BehatApiExtension\ArrayContainsComparator\Matcher\ArrayMaxLength')],
-                ['variableType', $this->isInstanceOf('Imbo\BehatApiExtension\ArrayContainsComparator\Matcher\VariableType')],
-                ['regExp', $this->isInstanceOf('Imbo\BehatApiExtension\ArrayContainsComparator\Matcher\RegExp')],
-                ['gt', $this->isInstanceOf('Imbo\BehatApiExtension\ArrayContainsComparator\Matcher\GreaterThan')],
-                ['lt', $this->isInstanceOf('Imbo\BehatApiExtension\ArrayContainsComparator\Matcher\LessThan')],
-                ['jwt', $this->isInstanceOf('Imbo\BehatApiExtension\ArrayContainsComparator\Matcher\JWT')]
+                ['arrayLength', $this->isInstanceOf(Matcher\ArrayLength::class)],
+                ['arrayMinLength', $this->isInstanceOf(Matcher\ArrayMinLength::class)],
+                ['arrayMaxLength', $this->isInstanceOf(Matcher\ArrayMaxLength::class)],
+                ['variableType', $this->isInstanceOf(Matcher\VariableType::class)],
+                ['regExp', $this->isInstanceOf(Matcher\RegExp::class)],
+                ['gt', $this->isInstanceOf(Matcher\GreaterThan::class)],
+                ['lt', $this->isInstanceOf(Matcher\LessThan::class)],
+                ['jwt', $this->isInstanceOf(Matcher\JWT::class)]
             )
             ->will($this->returnSelf());
 
@@ -37,13 +38,13 @@ class ArrayContainsComparatorAwareInitializerTest extends PHPUnit_Framework_Test
      * @covers ::initializeContext
      */
     public function testInjectsComparatorWhenInitializingContext() {
-        $comparator = $this->createMock('Imbo\BehatApiExtension\ArrayContainsComparator');
+        $comparator = $this->createMock(ArrayContainsComparator::class);
         $comparator
             ->expects($this->exactly(8))
             ->method('addFunction')
             ->will($this->returnSelf());
 
-        $context = $this->createMock('Imbo\BehatApiExtension\Context\ArrayContainsComparatorAwareContext');
+        $context = $this->createMock(ArrayContainsComparatorAwareContext::class);
         $context->expects($this->once())->method('setArrayContainsComparator')->with($comparator);
 
         $initializer = new ArrayContainsComparatorAwareInitializer($comparator);

--- a/tests/ServiceContainer/BehatApiExtensionTest.php
+++ b/tests/ServiceContainer/BehatApiExtensionTest.php
@@ -45,26 +45,6 @@ class BehatApiExtensionTest extends PHPUnit_Framework_TestCase {
 
     /**
      * @covers ::configure
-     * @expectedException Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
-     * @expectedExceptionMessage Invalid configuration for path "api_extension.apiClient.base_uri": Can't connect to base_uri: "http://localhost:123".
-     */
-    public function testThrowsExceptionWhenBuildingConfigurationAndBaseUriIsNotConnectable() {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root($this->extension->getConfigKey());
-
-        $this->extension->configure($rootNode);
-
-        (new Processor())->process($rootNode->getNode(true), [
-            'api_extension' => [
-                'apiClient' => [
-                    'base_uri' => 'http://localhost:123',
-                ],
-            ],
-        ]);
-    }
-
-    /**
-     * @covers ::configure
      */
     public function testCanOverrideDefaultValuesWhenBuildingConfiguration() {
         $treeBuilder = new TreeBuilder();

--- a/tests/ServiceContainer/BehatApiExtensionTest.php
+++ b/tests/ServiceContainer/BehatApiExtensionTest.php
@@ -53,28 +53,7 @@ class BehatApiExtensionTest extends PHPUnit_Framework_TestCase {
         // Configure the root node builder
         $this->extension->configure($rootNode);
 
-        // Set up a socket for the test case, try all ports between 8000 and 8079. If no ports are
-        // available the test case will be marked as skipped
-        set_error_handler(function() { return true; });
-        $sock = socket_create(AF_INET, SOCK_STREAM, SOL_TCP);
-
-        for ($port = 8000; $port < 8079; $port++) {
-            if ($result = socket_bind($sock, 'localhost', $port)) {
-                break;
-            }
-        }
-
-        restore_error_handler();
-
-        if (!$result) {
-            // No port was available
-            $this->markTestSkipped('Could not create a socket, skipping test for now.');
-        }
-
-        // Listen for connections
-        socket_listen($sock);
-
-        $baseUri = sprintf('http://localhost:%d', $port);
+        $baseUri = 'http://localhost:8888';
         $config = (new Processor())->process($rootNode->getNode(true), [
             'api_extension' => [
                 'apiClient' => [
@@ -88,8 +67,5 @@ class BehatApiExtensionTest extends PHPUnit_Framework_TestCase {
                 'base_uri' => $baseUri,
             ],
         ], $config);
-
-        // Close socket used in test case
-        socket_close($sock);
     }
 }


### PR DESCRIPTION
Validation of 'base_uri' in config definition makes throw error when behat
is executed without API server has been launched.

Problem is when run behat for other reason
that not was to test features, with "--help" for example, always stop with connection error.

Fixed changing validation location in api context initializer that throw
error only when we run test features, in other way behat runs ok.