### PR TITLE
Fix sprintf() if JSON response contains some % sign

### DIFF
--- a/src/Context/ApiContext.php
+++ b/src/Context/ApiContext.php
@@ -789,7 +789,7 @@ class ApiContext implements ApiClientAwareContext, ArrayContainsComparatorAwareC
 
         try {
             Assertion::isInstanceOf($body, 'stdClass', 'Expected response body to be a JSON object.');
-            Assertion::same('{}', $encoded = json_encode($body, JSON_PRETTY_PRINT), sprintf(
+            Assertion::same('{}', $encoded = str_replace('%', '%%', json_encode($body, JSON_PRETTY_PRINT)), sprintf(
                 'Expected response body to be an empty JSON object, got "%s".',
                 $encoded
             ));
@@ -813,7 +813,7 @@ class ApiContext implements ApiClientAwareContext, ArrayContainsComparatorAwareC
             Assertion::same(
                 [],
                 $body = $this->getResponseBodyArray(),
-                sprintf('Expected response body to be an empty JSON array, got "%s".', json_encode($body, JSON_PRETTY_PRINT))
+                sprintf('Expected response body to be an empty JSON array, got "%s".', str_replace('%', '%%', json_encode($body, JSON_PRETTY_PRINT)))
             );
         } catch (AssertionFailure $e) {
             throw new AssertionFailedException($e->getMessage());
@@ -842,7 +842,7 @@ class ApiContext implements ApiClientAwareContext, ArrayContainsComparatorAwareC
                     $length,
                     $length === 1 ? 'y' : 'ies',
                     count($body),
-                    json_encode($body, JSON_PRETTY_PRINT)
+                    str_replace('%', '%%', json_encode($body, JSON_PRETTY_PRINT))
                 )
             );
         } catch (AssertionFailure $e) {
@@ -874,7 +874,7 @@ class ApiContext implements ApiClientAwareContext, ArrayContainsComparatorAwareC
                     $length,
                     (int) $length === 1 ? 'y' : 'ies',
                     $bodyLength,
-                    json_encode($body, JSON_PRETTY_PRINT)
+                    str_replace('%', '%%', json_encode($body, JSON_PRETTY_PRINT))
                 )
             );
         } catch (AssertionFailure $e) {
@@ -906,7 +906,7 @@ class ApiContext implements ApiClientAwareContext, ArrayContainsComparatorAwareC
                     $length,
                     (int) $length === 1 ? 'y' : 'ies',
                     $bodyLength,
-                    json_encode($body, JSON_PRETTY_PRINT)
+                    str_replace('%', '%%', json_encode($body, JSON_PRETTY_PRINT))
                 )
             );
         } catch (AssertionFailure $e) {


### PR DESCRIPTION
## Problem
if the JSON response contains few percentage sign `%`, then the `Assert\Assertion` class throw a PHP error because the sprintf if corrupted.

For example [in there](https://github.com/beberlei/assert/blob/master/lib/Assert/Assertion.php#L1521)

## Reproduce
if the JSON response is **exactly** like this
```json
{
    "1": {
        "stringValue": "1\u00a0%"
    },
    "2": {
        "stringValue": "2\u00a0%"
    },
    "3": {
        "stringValue": "3\u00a0%"
    }
}
```
with behat test assert
```behat
And the response body is a JSON array of length 1
```
There is an error
```
Warning: sprintf(): Too few arguments in
vendor/beberlei/assert/lib/Assert/Assertion.php line 1882
```
