### PR TITLE
Add step to assert that the response body is empty

### DIFF
--- a/docs/guide/verify-server-response.rst
+++ b/docs/guide/verify-server-response.rst
@@ -188,6 +188,11 @@ Assert that the value of the ``:header`` response header matches the regular exp
 
 For more information regarding regular expressions and the usage of modifiers, `refer to the PHP manual <http://php.net/pcre>`_.
 
+Then the response body is empty
+-------------------------------
+
+Assert that the response body is empty.
+
 Then the response body is an empty JSON object
 ----------------------------------------------
 

--- a/features/bootstrap/index.php
+++ b/features/bootstrap/index.php
@@ -248,6 +248,13 @@ $app->get('/emptyObject', function (Request $request, Response $response): Respo
 });
 
 /**
+ * Return a response with an empty body
+ */
+$app->get('/empty', function (Request $request, Response $response): Response {
+    return $response->withStatus(204);
+});
+
+/**
  * Return a response with 403 Forbidden
  */
 $app->get('/403', function (Request $request, Response $response): Response {

--- a/features/verify-response-failures.feature
+++ b/features/verify-response-failures.feature
@@ -269,6 +269,25 @@ Feature: Assertion steps can fail
             ]". (Imbo\BehatApiExtension\Exception\AssertionFailedException)
             """
 
+    Scenario: Assert response body is empty failure
+        Given a file named "features/assert-response-body-is-empty.feature" with:
+            """
+            Feature: Make request and assert response body is empty
+                Scenario: Make request
+                    Given the request body is:
+                        '''
+                        content
+                        '''
+                    When I request "/echo"
+                    Then the response body is empty
+            """
+        When I run "behat features/assert-response-body-is-empty.feature"
+        Then it should fail
+        And the output should contain:
+            """
+            Expected response body to be empty, got "content". (Imbo\BehatApiExtension\Exception\AssertionFailedException)
+            """
+
     Scenario: Assert response body JSON array length failure
         Given a file named "features/assert-response-body-json-array-length.feature" with:
             """

--- a/features/verify-response.feature
+++ b/features/verify-response.feature
@@ -153,6 +153,23 @@ Feature: Test Then steps
             3 steps (3 passed)
             """
 
+    Scenario: Use Then step to verify responses with empty body
+        Given a file named "features/thens-empty-response-body.feature" with:
+            """
+            Feature: Test for empty response body
+                Scenario: Assert that the response body is empty
+                    When I request "/empty"
+                    Then the response body is empty
+            """
+        When I run "behat features/thens-empty-response-body.feature"
+        Then it should pass with:
+            """
+            ..
+
+            1 scenario (1 passed)
+            2 steps (2 passed)
+            """
+
     Scenario: Use Then steps to verify responses with numerical array as root
         Given a file named "features/response-with-numerical-array.feature" with:
             """

--- a/src/Context/ApiContext.php
+++ b/src/Context/ApiContext.php
@@ -1001,6 +1001,30 @@ class ApiContext implements ApiClientAwareContext, ArrayContainsComparatorAwareC
     }
 
     /**
+     * Assert that the response body is empty
+     *
+     * @throws AssertionFailedException
+     *
+     * @Then the response body is empty
+     */
+    public function assertResponseBodyIsEmpty(): bool
+    {
+        if (!$this->response) {
+            throw new RuntimeException($this->missingResponseError);
+        }
+
+        $body = (string) $this->response->getBody();
+
+        try {
+            Assertion::noContent($body, sprintf('Expected response body to be empty, got "%s".', $body));
+        } catch (AssertionFailure $e) {
+            throw new AssertionFailedException($e->getMessage());
+        }
+
+        return true;
+    }
+
+    /**
      * Assert that the response body contains an array with a specific length
      *
      * @param int|string $length The length of the array

--- a/tests/Context/ApiContextTest.php
+++ b/tests/Context/ApiContextTest.php
@@ -1148,6 +1148,38 @@ BAR;
     }
 
     /**
+     * @covers ::assertResponseBodyIsEmpty
+     */
+    public function testCanAssertThatTheResponseBodyIsEmpty(): void
+    {
+        $this->mockHandler->append(new Response(204));
+        $this->context->requestPath('/some/path');
+        $this->assertTrue($this->context->assertResponseBodyIsEmpty());
+    }
+
+    /**
+     * @covers ::assertResponseBodyIsEmpty
+     */
+    public function testCanAssertThatTheResponseBodyIsEmptyCanFail(): void
+    {
+        $this->mockHandler->append(new Response(200, [], 'some content'));
+        $this->context->requestPath('/some/path');
+        $this->expectException(AssertionFailedException::class);
+        $this->expectExceptionMessage('Expected response body to be empty, got "some content".');
+        $this->assertTrue($this->context->assertResponseBodyIsEmpty());
+    }
+
+    /**
+     * @covers ::assertResponseBodyIsEmpty
+     */
+    public function testAssertThatTheResponseBodyIsEmptyThrowsExceptionOnMissingResponse(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('The request has not been made yet, so no response object exists.');
+        $this->context->assertResponseBodyIsEmpty();
+    }
+
+    /**
      * @dataProvider getResponseBodyArrays
      * @covers ::assertResponseBodyJsonArrayLength
      * @covers ::getResponseBodyArray


### PR DESCRIPTION
This PR adds a new step that can be used to verify that the response body is empty:

    Then the response body is empty

Resolves #105
