### PR TITLE
Add support for firebase/php-jwt at version 6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ docs/_build
 .phpunit.result.cache
 .vscode
 .php-cs-fixer.cache
+auth.json

--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,3 @@ docs/_build
 .phpunit.result.cache
 .vscode
 .php-cs-fixer.cache
-auth.json

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "ext-json": "*",
     "beberlei/assert": "^3.3",
     "behat/behat": "^3.8",
-    "firebase/php-jwt": "^5.2",
+    "firebase/php-jwt": "^5.2 || ^6.0",
     "guzzlehttp/guzzle": "^7.3"
   },
   "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "ext-json": "*",
     "beberlei/assert": "^3.3",
     "behat/behat": "^3.8",
-    "firebase/php-jwt": "^5.2 || ^6.0",
+    "firebase/php-jwt": "^5.2 || ^6.3",
     "guzzlehttp/guzzle": "^7.3"
   },
   "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6a291fbc567d929e35f32dc565376698",
+    "content-hash": "07971c24e3d1b89cbca501b589fdf272",
     "packages": [
         {
             "name": "beberlei/assert",
@@ -273,23 +273,28 @@
         },
         {
             "name": "firebase/php-jwt",
-            "version": "v5.5.1",
+            "version": "v6.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/firebase/php-jwt.git",
-                "reference": "83b609028194aa042ea33b5af2d41a7427de80e6"
+                "reference": "018dfc4e1da92ad8a1b90adc4893f476a3b41cb8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/firebase/php-jwt/zipball/83b609028194aa042ea33b5af2d41a7427de80e6",
-                "reference": "83b609028194aa042ea33b5af2d41a7427de80e6",
+                "url": "https://api.github.com/repos/firebase/php-jwt/zipball/018dfc4e1da92ad8a1b90adc4893f476a3b41cb8",
+                "reference": "018dfc4e1da92ad8a1b90adc4893f476a3b41cb8",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.0"
+                "php": "^7.1||^8.0"
             },
             "require-dev": {
-                "phpunit/phpunit": ">=4.8 <=9"
+                "guzzlehttp/guzzle": "^6.5||^7.4",
+                "phpspec/prophecy-phpunit": "^1.1",
+                "phpunit/phpunit": "^7.5||^9.5",
+                "psr/cache": "^1.0||^2.0",
+                "psr/http-client": "^1.0",
+                "psr/http-factory": "^1.0"
             },
             "suggest": {
                 "paragonie/sodium_compat": "Support EdDSA (Ed25519) signatures when libsodium is not present"
@@ -324,9 +329,9 @@
             ],
             "support": {
                 "issues": "https://github.com/firebase/php-jwt/issues",
-                "source": "https://github.com/firebase/php-jwt/tree/v5.5.1"
+                "source": "https://github.com/firebase/php-jwt/tree/v6.3.0"
             },
-            "time": "2021-11-08T20:18:51+00:00"
+            "time": "2022-07-15T16:48:45+00:00"
         },
         {
             "name": "guzzlehttp/guzzle",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "07971c24e3d1b89cbca501b589fdf272",
+    "content-hash": "6cc2663770b195cdbb5830f62b9a3f7c",
     "packages": [
         {
             "name": "beberlei/assert",


### PR DESCRIPTION
As the firebase/php-jwt has an active vulnerability with a CVSS score of 7.5 (high) for every version below 6, there should be the possibility to upgrade that package. I made it optional to give the opportunity for other to adapt their code, if any dependencies are present.

Details of vulnerability can be found here:
https://security.snyk.io/vuln/SNYK-PHP-FIREBASEPHPJWT-2434829